### PR TITLE
Fix missing response on webhook

### DIFF
--- a/server/routes/issueHook.js
+++ b/server/routes/issueHook.js
@@ -14,6 +14,9 @@ const routes = server => {
           console.error('Restify error: ', e)
           res.send(500, { msg: 'bad' })
         })
+    } else {
+      // acknowledge other actions to avoid hanging the request
+      res.send({ msg: 'ignored' })
     }
   })
 }


### PR DESCRIPTION
## Summary
- handle non-opened issue events

## Testing
- `npm install --silent`
- `node -c server/routes/issueHook.js`


------
https://chatgpt.com/codex/tasks/task_e_684cdaddf1fc832699eb276e8ce8286d